### PR TITLE
fix(importer): Sort RAR files before processing

### DIFF
--- a/internal/importer/rar_processor.go
+++ b/internal/importer/rar_processor.go
@@ -74,6 +74,11 @@ func (rh *rarProcessor) AnalyzeRarContentFromNzb(ctx context.Context, rarFiles [
 		return nil, NewNonRetryableError("no pool manager available", nil)
 	}
 
+	// Sort rar files by filename to ensure consistent ordering
+	sort.Slice(rarFiles, func(i, j int) bool {
+		return rarFiles[i].Filename < rarFiles[j].Filename
+	})
+
 	// Rename RAR files to match the first file's base name that will allow parse rar that have different files name
 	sortFiles := renameRarFilesAndSort(rarFiles)
 


### PR DESCRIPTION
The RAR processor was failing to analyze some archives due to an incorrect processing order. The `renameRarFilesAndSort` function was attempting to normalize filenames based on the first file in the list it received. However, the list was not guaranteed to be sorted, which could lead to an incorrect base name being chosen for renaming.

This change adds a step to sort the RAR files by filename before they are processed. This ensures that the files are always in the correct order (e.g., `part01.rar` before `part02.rar`), making the renaming process deterministic and preventing "RAR signature not found" errors.