### PR TITLE
Fix speedtest provider name matching in pool lookup

### DIFF
--- a/internal/api/provider_speedtest_handler.go
+++ b/internal/api/provider_speedtest_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -108,9 +109,15 @@ func (s *Server) runProviderSpeedTest(ctx context.Context, p *config.ProviderCon
 	if s.poolManager != nil {
 		if cp, err := s.poolManager.GetPool(); err == nil && cp != nil {
 			if real, ok := cp.(*nntppool.Client); ok {
-				providerName := p.Host
+				// Match the name the production pool registers for this
+				// provider: ToNNTPProvider sets Host = "host:port", and
+				// nntppool's resolveProviderName derives "host:port+user".
+				// Building the lookup from p.Host alone (no port) never
+				// matches, forcing the slow coordinator fallback.
+				host := fmt.Sprintf("%s:%d", p.Host, p.Port)
+				providerName := host
 				if p.Username != "" {
-					providerName = p.Host + "+" + p.Username
+					providerName = host + "+" + p.Username
 				}
 				// Try the production pool first. If the provider isn't
 				// in it, nntppool returns an error and we fall through

--- a/internal/api/provider_speedtest_handler.go
+++ b/internal/api/provider_speedtest_handler.go
@@ -62,7 +62,20 @@ func (s *Server) handleTestProviderSpeed(c *fiber.Ctx) error {
 	if err != nil {
 		return RespondInternalError(c, "Speed test failed", err.Error())
 	}
-	speed := result.WireSpeedBps / 1024 / 1024 // bytes/sec → MB/s
+	// Prefer the targeted provider's per-provider wire speed over the
+	// client-wide aggregate. WireSpeedBps divides the whole-client
+	// BytesConsumed delta by elapsed, so on the shared production pool
+	// any concurrent stream or other provider's traffic during the test
+	// window inflates it. result.Providers carries the delta-based,
+	// per-provider speed for exactly the provider we targeted.
+	wireBps := result.WireSpeedBps
+	for _, ps := range result.Providers {
+		if ps.AvgSpeed > 0 {
+			wireBps = ps.AvgSpeed
+			break
+		}
+	}
+	speed := wireBps / 1024 / 1024 // bytes/sec → MB/s
 
 	// Update provider config with speed test result
 	now := time.Now()

--- a/internal/api/speedtest_coordinator.go
+++ b/internal/api/speedtest_coordinator.go
@@ -149,12 +149,21 @@ func (sc *speedtestCoordinator) getOrBuildClient(ctx context.Context, p *config.
 		}
 	}
 
+	// Mirror the production pool (ToNNTPProvider): without Inflight the
+	// nntppool client defaults to depth 1, making the fallback path
+	// latency-bound (one BODY per RTT) instead of pipelined.
+	inflight := p.InflightRequests
+	if inflight <= 0 {
+		inflight = 10
+	}
+
 	client, err := nntppool.NewClient(ctx, []nntppool.Provider{
 		{
 			Host:        host,
 			TLSConfig:   tlsCfg,
 			Auth:        nntppool.Auth{Username: p.Username, Password: p.Password},
 			Connections: p.MaxConnections,
+			Inflight:    inflight,
 			IdleTimeout: 60 * time.Second,
 		},
 	})


### PR DESCRIPTION
fix(speedtest): match production pool provider name and pipeline fallback
Bug 1: build the production-pool lookup name from host:port (+username)
so it matches nntppool's resolveProviderName, instead of host alone which
never matched and always forced the slow coordinator fallback.

Bug 2: set Inflight on the coordinator client (configured inflight_requests,
default 10) so the fallback path pipelines instead of running depth-1.